### PR TITLE
Allow selection of only repo url

### DIFF
--- a/templates/repo-navbar.html
+++ b/templates/repo-navbar.html
@@ -1,5 +1,5 @@
 <h1><a href="/">index</a>/{{repo|repo_name}}</h1>
 <div>{{repo|description}}</div>
-<div class="clone-url">git clone {{crate::CONFIG.clone_base}}/{{repo|repo_name}}</div>
+<div class="clone-url">git clone <a>{{crate::CONFIG.clone_base}}/{{repo|repo_name}}</a></div>
 <div class="navbar"><a href="/{{repo|repo_name|urlencode_strict}}">README</a> |  <a href="/{{repo|repo_name|urlencode_strict}}/tree">tree</a> |  <a href="/{{repo|repo_name|urlencode_strict}}/log">log</a> |  <a href="/{{repo|repo_name|urlencode_strict}}/refs">refs</a></div>
 <hr class='thin'>


### PR DESCRIPTION
Current behavior only allows for the selection of the full text, with an added <a> tag it selects all for the first click, double click selects only the URL.

On chromium it doesn't seem to affect anything outside of the css colors. Double click behavior was tested with Firefox and chromium on linux.